### PR TITLE
feat: add support for  file wildcards for log file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,5 @@ package-lock.json
 demo.js
 
 !test/fixtures/files/package-lock.json
+
+.vscode

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   "dependencies": {
     "address": "^1.1.2",
     "formstream": "^1.1.0",
+    "glob": "^7.1.6",
     "moment": "^2.28.0",
     "nounou": "^1.2.1",
     "p-map": "^4.0.0",

--- a/test/errorlog.test.js
+++ b/test/errorlog.test.js
@@ -15,6 +15,18 @@ const { getErrorText, setErrorText } = baseContext;
 
 const { MAX_ERROR_COUNT } = errorLogLib;
 
+describe('find error files with given filter', function() {
+  const errors = [
+    path.join(__dirname, 'fixtures/files/error-*.txt'),
+  ];
+  const context = Object.assign({}, baseContext, { errors });
+  it('should get two files', async function() {
+    await errorLogLib.init.call(context);
+    const message = await errorLogLib.call(context);
+    expect(Object.keys(message.data).length).to.be(2);
+  });
+});
+
 describe('get error logs', function() {
   const errors = [];
   const context = Object.assign({}, baseContext, { errors });

--- a/test/fixtures/files/error-0.txt
+++ b/test/fixtures/files/error-0.txt
@@ -1,0 +1,7 @@
+2020-06-03 21:27:54,998 ERROR 82365 nodejs.ClusterClientNoResponseError: client no response in 3562068ms exceeding maxIdleTime 60000ms, maybe the connection is close on other side.
+    at Timeout._onTimeout (/Users/hyj1991/git/monitor/xprofiler-console/node_modules/cluster-client/lib/leader.js:77:23)
+    at listOnTimeout (internal/timers.js:549:17)
+    at processTimers (internal/timers.js:492:7)
+name: "ClusterClientNoResponseError"
+pid: 82365
+hostname: hyj1991-MacBook-Pro

--- a/test/fixtures/files/error-1.txt
+++ b/test/fixtures/files/error-1.txt
@@ -1,0 +1,9 @@
+2020-06-03 21:27:54,998 ERROR 82365 nodejs.ClusterClientNoResponseError: client no response in 3562068ms exceeding maxIdleTime 60000ms, maybe the connection is close on other side.
+    at Timeout._onTimeout (/Users/hyj1991/git/monitor/xprofiler-console/node_modules/cluster-client/lib/leader.js:77:23)
+    at listOnTimeout (internal/timers.js:549:17)
+    at processTimers (internal/timers.js:492:7)
+name: "ClusterClientNoResponseError"
+pid: 82365
+hostname: hyj1991-MacBook-Pro
+
+


### PR DESCRIPTION
The config of `error_log` can only be full name now , but sometime we use series of file with different suffix.
So I pull this request to support it. 