### PR TITLE
chore: use logger.warn when find node pwd failed

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
-        node-version: [ 8, 9, 10, 11, 12, 13, 14, 15, 16, 17 ]
+        node-version: [ 8, 10, 12, 14, 16, 17 ]
     steps:
     - name: Checkout Git Source
       uses: actions/checkout@master

--- a/orders/report_core.js
+++ b/orders/report_core.js
@@ -52,7 +52,7 @@ async function getNodePwd(pid) {
       pwd = null;
     }
   } catch (err) {
-    logger.error(`getNodePwd failed: ${err}`);
+    logger.warn(`getNodePwd failed: ${err}`);
   }
 
   return pwd;


### PR DESCRIPTION
> https://github.com/X-Profiler/xtransit/pull/37/files#diff-9c943ad7a32b1d71763a565a15f132e0ef8a20f188b682a251bc5b922596b90a

在 scan core dir 的过程中，可能存在扫描到 node 临时子进程的情况，因此此处查询临时 node 进程 pwd 目录失败日志需要调整为 `warn` 级别，即查询失败一般也不会在线上输出