### PR TITLE
feat: support custom agentId

### DIFF
--- a/commands/xprofctl.js
+++ b/commands/xprofctl.js
@@ -10,7 +10,10 @@ const realpath = promisify(fs.realpath);
 const getNodeExe = require('../common/exe');
 
 const args = process.argv.slice(2);
-let pid, tid = 0, command, options;
+let pid,
+  tid = 0,
+  command,
+  options;
 if (args.length === 4) {
   [pid, tid, command, options] = args;
 } else {

--- a/common/utils.js
+++ b/common/utils.js
@@ -13,7 +13,11 @@ exports.random = function(max, min = 0) {
   return Number(parseFloat(Math.random() * (max - min) + min).toFixed(2));
 };
 
-exports.getAgentId = function(ipMode) {
+exports.getAgentId = function(customAgent, ipMode) {
+  if (typeof customAgent === 'function') {
+    return customAgent();
+  }
+
   if (!ipMode) {
     return `${os.hostname()}`;
   }

--- a/index.d.ts
+++ b/index.d.ts
@@ -10,7 +10,7 @@ export interface XtransitConfig {
   disks?: string[], // 数组，每一项为配置需要监控的 disk 目录全路径
   errors?: string[], // 数组，每一项为配置需要监控的 error 日志文件全路径
   packages?: string[], // 数组，每一项为配置需要监控的 package.json 文件全路径，并且要保证存在平级的 lock 文件（package-lock.json 或者 yarn.lock）
-  
+
   // III. 不是很重要的可选的配置（不知道怎么配置的别传任何值，key 也别传，整个配置留空！！）
   logDir?: string, // xprofiler 插件生成性能日志文件的目录，默认两者均为 os.tmpdir() 如：'/path/to/xprofiler_output'
   docker?: boolean, // 默认 false，系统数据采集会依赖当前是否是 docker 环境而进行一些特殊处理，可以手动强制指定当前实例是否为 docker 环境
@@ -21,6 +21,7 @@ export interface XtransitConfig {
   logLevel?: number, // 默认内置 logger 的日志级别，0 error，1 info，2 warning，3 debug,
   titles?: string[], // 数组，如果应用使用了 process.title 自定义了名称，可以通过配置这里上报进程数据,
   cleanAfterUpload?: boolean, // 默认 false，如果设置为 true 则会在转储本地性能文件成功后删除本地的性能文件
+  customAgent?: () => string | undefined, // 默认 undefined，如果设置则会使用此函数计算 agentId
 }
 
 /**

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -42,6 +42,7 @@ class XtransitAgent extends EventEmitter {
     this.titles = Array.from(new Set(config.titles || []));
     this.lookup = typeof config.lookup === 'function' ? config.lookup : async server => server;
     this.commands = this.formatCommands(config.commands);
+    this.customAgent = config.customAgent;
 
     // global var
     this.conn = null;
@@ -153,7 +154,7 @@ class XtransitAgent extends EventEmitter {
   sendMessage(type, data = {}, traceId) {
     const message = {};
     message.appId = this.appId;
-    message.agentId = utils.getAgentId(this.ipMode);
+    message.agentId = utils.getAgentId(this.customAgent, this.ipMode);
     message.traceId = traceId || uuidv4();
     message.clientId = this.clientId;
     message.timestamp = Date.now();

--- a/lib/handler.js
+++ b/lib/handler.js
@@ -88,7 +88,7 @@ module.exports = async function(message) {
       const execOptions = {
         timeout: expiredTime || 3000,
         env: Object.assign({
-          XTRANSIT_AGENT_ID: utils.getAgentId(this.ipMode),
+          XTRANSIT_AGENT_ID: utils.getAgentId(this.customAgent, this.ipMode),
           XTRANSIT_LOGDIR: this.logdir,
           XTRANSIT_EXPIRED_TIME: expiredTime,
           XTRANSIT_TITLES: JSON.stringify(this.titles),

--- a/test/fixtures/transit-client.js
+++ b/test/fixtures/transit-client.js
@@ -59,6 +59,9 @@ xtransit.start({
     console.log('[transit-client] wait for server lookup...');
     return await new Promise(resolve => setTimeout(() => resolve(server), 10));
   },
+  customAgent: process.env.UNIT_TEST_TRANSIT_CUSTOM_AGENT === 'YES' ? () => {
+    return 'mock-agent-id';
+  } : undefined,
 });
 
 function close() {


### PR DESCRIPTION
此 PR 旨在增加自定义 `agentId` 配置，以便在默认的 `os.hostname` 以及 `ip` 组合无法满足需求时，完全使用自定义的逻辑生成实例的唯一标识符。

需要注意的是，`customAgent` 对应的函数，需要保证不同实例返回的 `agentId` 唯一，否则会引发监控数据错乱的问题。