### PR TITLE
feat: support custom command overriding built-in commands

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -69,7 +69,7 @@ class XtransitAgent extends EventEmitter {
 
   formatCommands(commands) {
     commands = Array.from(new Set(commands || []));
-    commands.unshift(path.join(__dirname, '../commands'));
+    commands.push(path.join(__dirname, '../commands'));
     return commands;
   }
 

--- a/lib/handler.js
+++ b/lib/handler.js
@@ -99,7 +99,8 @@ module.exports = async function(message) {
       // exec command
       const nodeExe = await getNodeExe(process.pid, false);
       this.logger.debug(`[execute command] ${nodeExe} ${args.join(' ')}`);
-      const { stdout, stderr } = await execFile(nodeExe, args, execOptions);
+      const { stdout, stderr: error } = await execFile(nodeExe, args, execOptions);
+      const stderr = stdout ? '' : error;
 
       // check action file status
       checkActionFile.call(this, cmd, args.pop(), stdout, stderr, this.logger);

--- a/test/xtransit.test.js
+++ b/test/xtransit.test.js
@@ -166,7 +166,7 @@ describe('running xtransit', function() {
 
       if (data.ok) {
         console.log(`[xtransit.test.js] command [${data.command}] override: ${expect.override}, stdout: <${data.data.stdout}>`);
-        expect.override === false && assert(!data.data.stdout.includes(`my ${data.command}.js`));
+        expect.override === false && assert(data.data.stdout.includes(`my ${data.command}.js`));
       }
     }
   });


### PR DESCRIPTION
`commands` 修改为 `push` 模式，以支持多语言下的语言相关进程获取脚本

Reference: https://github.com/X-Profiler/xprofiler/issues/228